### PR TITLE
Updates to metatensor/metatomic stack

### DIFF
--- a/repos/spack_repo/builtin/packages/libmetatensor/package.py
+++ b/repos/spack_repo/builtin/packages/libmetatensor/package.py
@@ -29,5 +29,8 @@ class Libmetatensor(CMakePackage):
     depends_on("cxx", type="build")
 
     def cmake_args(self):
-        args = [self.define_from_variant("METATENSOR_INSTALL_BOTH_STATIC_SHARED", "static")]
+        args = [
+            self.define("METATENSOR_INSTALL_BOTH_STATIC_SHARED", "OFF"),
+            self.define_from_variant("BUILD_SHARED_LIBS", "static"),
+        ]
         return args

--- a/repos/spack_repo/builtin/packages/libmetatensor_torch/package.py
+++ b/repos/spack_repo/builtin/packages/libmetatensor_torch/package.py
@@ -17,10 +17,10 @@ class LibmetatensorTorch(CMakePackage):
     maintainers("HaoZeke", "luthaf", "rmeli")
     license("BSD-3-Clause", checked_by="HaoZeke")
 
-    version("0.7.6", sha256="8dcc07c86094034facba09ebcc6b52f41847c2413737c8f9c88ae0a2990f8d41")
+    version("0.8.0", sha256="61d383ce958deafe0e3916088185527680c9118588722b17ec5c39cfbaa6da55")
 
     depends_on("cmake@3.16:", type="build")
     depends_on("cxx", type="build")
     depends_on("c", type="build")
-    depends_on("libmetatensor@0.1.14:0.2.0", type=("build", "run"))
-    depends_on("py-torch@2.1.0:2.7.0", type=("build", "run"))
+    depends_on("libmetatensor@0.1.14:0.1")
+    depends_on("py-torch@2.1.0:2.7.0")

--- a/repos/spack_repo/builtin/packages/libmetatomic_torch/package.py
+++ b/repos/spack_repo/builtin/packages/libmetatomic_torch/package.py
@@ -11,16 +11,16 @@ class LibmetatomicTorch(CMakePackage):
     """TorchScript/C++ bindings to metatomic"""
 
     homepage = "https://docs.metatensor.org/metatomic"
-    url = "https://github.com/metatensor/metatomic/releases/download/metatomic-torch-v0.1.3/metatomic_torch-0.1.3.tar.gz"
+    url = "https://github.com/metatensor/metatomic/releases/download/metatomic-torch-v0.1.4/metatomic-torch-cxx-0.1.4.tar.gz"
     git = "https://github.com/metatensor/metatomic.git"
 
     maintainers("HaoZeke", "luthaf", "rmeli")
     license("BSD-3-Clause", checked_by="HaoZeke")
 
-    version("0.1.3", sha256="60a4b651cf6e15f175879af74d18215d45cc4fd5e42a61242a180e2014fe9fd2")
+    version("0.1.4", sha256="385ec8b8515d674b6a9f093f724792b2469e7ea2365ca596f574b64e38494f94")
 
     depends_on("cmake@3.16:", type="build")
     depends_on("cxx", type="build")
     depends_on("c", type="build")
-    depends_on("libmetatensor-torch@0.7.6:", type=("build", "run"))
+    depends_on("libmetatensor-torch@0.8.0:")
     depends_on("py-torch@2.1.0:2.7.0")

--- a/repos/spack_repo/builtin/packages/py_metatensor_torch/package.py
+++ b/repos/spack_repo/builtin/packages/py_metatensor_torch/package.py
@@ -13,14 +13,14 @@ class PyMetatensorTorch(PythonPackage):
     homepage = "https://docs.metatensor.org"
     pypi = "metatensor-torch/metatensor_torch-0.7.5.tar.gz"
 
-    import_modules = ["metatensor"]
+    import_modules = ["metatensor.torch"]
 
     maintainers("HaoZeke", "luthaf", "rmeli")
     license("BSD-3-Clause", checked_by="HaoZeke")
 
-    version("0.7.6", sha256="bcc23b535e5b86c0d49096cbf73de67141896f4f14c114515d97b936a78353a1")
+    version("0.8.0", sha256="240ea8c37328f6bb61ec9f3e482131f0875c73166a0e349a8dd8b85204c58bd7")
 
-    depends_on("py-vesin", type=("run", "build"))
+    depends_on("py-vesin", type=("build", "run"))
     depends_on("py-torch@2.1:", type=("build", "run"))
     depends_on("py-metatensor-core@0.1.13:0.1", type=("build", "run"))
 

--- a/repos/spack_repo/builtin/packages/py_metatensor_torch/package.py
+++ b/repos/spack_repo/builtin/packages/py_metatensor_torch/package.py
@@ -6,6 +6,8 @@ from spack_repo.builtin.build_systems.python import PythonPackage
 
 from spack.package import *
 
+import os
+
 
 class PyMetatensorTorch(PythonPackage):
     """Torchscript bindings for metatensor"""
@@ -29,3 +31,25 @@ class PyMetatensorTorch(PythonPackage):
     depends_on("py-setuptools@77:", type="build")
     depends_on("py-packaging@23:", type="build")
     depends_on("cmake@3.16:", type="build")
+
+
+    @run_after("install")
+    def workaround(self):
+        """
+        Workaround for the incorrect usage of namespace packages.
+
+        See https://github.com/metatensor/metatensor/issues/976 
+        """
+        python = self.spec["python"]
+        python_version = python.version.up_to(2)
+
+        metatensor_core = os.path.join(self.spec["py-metatensor-core"].prefix.lib, f"python{python_version}", "site-packages", "metatensor")
+        metatensor_torch = os.path.join(self.prefix.lib, f"python{python_version}", "site-packages", "metatensor", "torch")
+
+        dest = os.path.join(metatensor_core, "torch")
+
+        if os.path.lexists(dest):
+            os.remove(dest)
+
+        symlink(metatensor_torch, dest)
+

--- a/repos/spack_repo/builtin/packages/py_metatomic_torch/package.py
+++ b/repos/spack_repo/builtin/packages/py_metatomic_torch/package.py
@@ -11,8 +11,6 @@ class PyMetatomicTorch(PythonPackage):
     """Torchscript bindings for metatomic"""
 
     homepage = "https://docs.metatensor.org/metatomic"
-    url = "https://github.com/metatensor/metatomic/releases/download/metatomic-torch-v0.1.2/metatomic_torch-0.1.2.tar.gz"
-    git = "https://github.com/metatensor/metatomic.git"
     pypi = "metatomic-torch/metatomic-torch-0.1.2.tar.gz"
 
     import_modules = ["metatomic.torch"]
@@ -20,12 +18,12 @@ class PyMetatomicTorch(PythonPackage):
     maintainers("HaoZeke", "luthaf", "rmeli")
     license("BSD-3-Clause", checked_by="HaoZeke")
 
-    version("0.1.3", sha256="60a4b651cf6e15f175879af74d18215d45cc4fd5e42a61242a180e2014fe9fd2")
+    version("0.1.4", sha256="c593bbc0fa3a410bd19d4a4a8d0008d5bd1c31a9faaca85b9d6b655ee1133bde")
 
     depends_on("python@3.9:", type=("build", "run"))
-    depends_on("py-vesin", type=("run", "build"))
+    depends_on("py-vesin", type=("build", "run"))
     depends_on("py-torch@2.1:", type=("build", "run"))
-    depends_on("py-metatensor-torch@0.7", type=("build", "run"))
+    depends_on("py-metatensor-torch@0.8", type=("build", "run"))
     # >=0.3.0 and <0.4.0
     depends_on("py-metatensor-operations@0.3", type=("build", "run"))
     # pyproject.toml

--- a/repos/spack_repo/builtin/packages/py_metatomic_torch/package.py
+++ b/repos/spack_repo/builtin/packages/py_metatomic_torch/package.py
@@ -31,3 +31,4 @@ class PyMetatomicTorch(PythonPackage):
     depends_on("py-packaging@23:", type="build")
     # CMakeLists.txt
     depends_on("cmake@3.16:", type="build")
+


### PR DESCRIPTION
With these changes, I was able to build the following stack:

```yaml
spack:
  specs:
    - libmetatensor@0.1.17
    - libmetatensor-torch@0.8.0
    - libmetatomic-torch@0.1.4
    - py-metatensor-core
    - py-metatensor-learn
    - py-metatensor-operations
    - py-metatensor-torch
    - py-metatomic-torch
    - py-vesin
    - py-ase
    - py-ipython
  packages:
    all:
      prefer:
        - +cuda
        - cuda_arch=89
    py-torch:
      require:
        - ~distributed
        - ~magma
        - ~nccl
        - ~valgrind
        - +custom-protobuf
    blas:
      require: "openblas"
    lapack:
      require: "openblas"
    scalapack:
      require: "netlib-scalapack"
    fftw-api:
      require: "fftw" 
  view:
    root: ./spack-view
  concretizer:
    unify: true
```

I was then able to run the `metatomic` ASE tutorial, as a small test.

Getting things to work requires an ugly workaround. See https://github.com/metatensor/metatensor/issues/976 for details.